### PR TITLE
disable use password text when fail biometrics in ios

### DIFF
--- a/src/hooks/useBiometrics.ts
+++ b/src/hooks/useBiometrics.ts
@@ -62,6 +62,7 @@ const useBiometrics = (): UseBiometrics => {
     const result = await LocalAuthentication.authenticateAsync({
       disableDeviceFallback: true,
       cancelLabel: 'Cancel',
+      fallbackLabel: '',
     });
 
     return result.success;


### PR DESCRIPTION
# What ?
Disable `Use password` text when fail biometrics in ios 