### PR TITLE
fix build react native vision camera fail due to androidx.browser version

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -306,6 +306,10 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
+    // vision camera
+    implementation ('androidx.browser:browser:1.4.0') {
+        force = true
+    }
 
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules


### PR DESCRIPTION
# What ? 
fix build react native vision camera fail due to androidx.browser version

# How ?
- Use stable version of androidx.browser 